### PR TITLE
Fix lineSpacing for slides

### DIFF
--- a/finish/slides.js
+++ b/finish/slides.js
@@ -76,7 +76,7 @@ function createSlideJSON(licenseData, index) {
       objectId: `${ID_TITLE_SLIDE_BODY}_${index}`,
       fields: '*',
       style: {
-        lineSpacing: 10,
+        lineSpacing: 100.0,
         spaceAbove: {magnitude: 0, unit: 'PT'},
         spaceBelow: {magnitude: 0, unit: 'PT'},
       }


### PR DESCRIPTION
Current setting at value "10" means make line spacing 10% of normal and squishes all the lines together on the body of the generated slide. value of "100.0" is normal. I think single line spacing. Looks better and is more readable on generated slides.